### PR TITLE
replace BrowserRouter with HashRouter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {
 	Route,
-	BrowserRouter,
+	HashRouter,
 	Routes as Switch,
 } from "react-router-dom/dist/index.js";
 import "./App.css";
@@ -16,7 +16,7 @@ import {
 
 function App() {
 	return (
-		<BrowserRouter basename={process.env.PUBLIC_URL}>
+		<HashRouter basename={process.env.PUBLIC_URL}>
 			<Navbar />
 			<Switch>
 				<Route path="/" exact element={<Home />}></Route>
@@ -33,7 +33,7 @@ function App() {
 				></Route>
 				<Route path="/prof-page" exact element={<ProfPage />}></Route>
 			</Switch>
-		</BrowserRouter>
+		</HashRouter>
 	);
 }
 


### PR DESCRIPTION
- GitHub pages does not support client side routing
- Before this change, the site showed a 404 page when the page was refreshed or when the url was typed in
- This change fixes the issue since the GitHub pages server ignores everything in the url after the #